### PR TITLE
Add hosting of documentation on GitHub Pages

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,4 +1,4 @@
-name: Pages
+name: Deploy Documentation
 on:
   push:
     branches:
@@ -11,13 +11,9 @@ jobs:
         uses: actions/checkout@master
         with:
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-      - name: Update docs
-        run: |
-          pip install .
-          pip install sphinx sphinx-rtd-theme
-          cd doc
-          make html
-      - name: Build and Commit
+      - name: Install ANNchor from git
+        run: pip install .
+      - name: Build and Commit docs
         uses: sphinx-notes/pages@master
         with:
           documentation_path: doc

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,19 @@
+name: Pages
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - name: Build and Commit
+        uses: sphinx-notes/pages@master
+        with:
+          documentation_path: doc
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,5 +1,8 @@
 name: Pages
-on: [push]
+on:
+  push:
+    branches:
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -8,6 +8,12 @@ jobs:
         uses: actions/checkout@master
         with:
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - name: Update docs
+        run: |
+          pip install .
+          pip install sphinx sphinx-rtd-theme
+          cd doc
+          make html
       - name: Build and Commit
         uses: sphinx-notes/pages@master
         with:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A python library implementing ANNchor:<br>
 *k*-nearest neighbour graph construction for slow metrics.
 
 ## User Guide
-For user guide and documentation, go to ```/doc/_build/index.html```
+For user guide and documentation visit [gchq.github.io/annchor](https://gchq.github.io/annchor)
 
 <br></br>
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         "numpy>=1.21.0",
         "numba>=0.53.1",
         "python-Levenshtein>=0.12.2",
+        "pynndescent>=0.5.4",
         "scipy>=1.7.0",
         "sklearn>=0.0",
         "tqdm>=4.61.2",


### PR DESCRIPTION
This PR adds the hosting of documentation on GitHub pages.

It adds a github actions workflow which will build and push documentation when any changes are made to the main branch.
It also adds the pynndescent requirement to the `setup.py` file as this is now a dependency. 