### PR TITLE
Added repo to sys.path in conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -4,6 +4,16 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+from pathlib import Path
+import sys
+
+CONF_FILE_PATH = Path(__file__).absolute()
+SOURCE_FOLDER_PATH = CONF_FILE_PATH.parent
+DOCS_FOLDER_PATH = SOURCE_FOLDER_PATH.parent
+REPO_FOLDER_PATH = DOCS_FOLDER_PATH.parent
+
+sys.path.extend([str(DOCS_FOLDER_PATH), str(SOURCE_FOLDER_PATH), str(REPO_FOLDER_PATH)])
+
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Although many will build the documentation with the repo set to their current directory, it appears that ReadTheDocs **does not** do this. It's not confirmed, but we see this error:

<details>

<summary>Command output</summary>

```shell
$ python -m sphinx -T -W --keep-going -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html

Running Sphinx v7.4.7
--
  | loading translations [en]... done
  | building [mo]: targets for 0 po files that are out of date
  | writing output...
  | building [html]: targets for 5 source files that are out of date
  | updating environment: [new config] 5 added, 0 changed, 0 removed
  | reading sources... [ 20%] api
  | reading sources... [ 40%] index
  | reading sources... [ 60%] parallelisation
  | reading sources... [ 80%] parameters
  | reading sources... [100%] user_guide
  |  
  | WARNING: autodoc: failed to import class 'Annchor' from module 'annchor'; the following exception was raised:
  | No module named 'annchor'
  | WARNING: autodoc: failed to import class 'BruteForce' from module 'annchor'; the following exception was raised:
  | No module named 'annchor'
  | WARNING: autodoc: failed to import function 'compare_neighbor_graphs' from module 'annchor'; the following exception was raised:
  | No module named 'annchor'
  | WARNING: autodoc: failed to import module 'datasets' from module 'annchor'; the following exception was raised:
  | No module named 'annchor'
  | looking for now-outdated files... none found
  | pickling environment... done
  | checking consistency... done
  | preparing documents... done
  | copying assets...
  | copying static files... done
  | copying extra files... done
  | copying assets: done
  | writing output... [ 20%] api
  | writing output... [ 40%] index
  | writing output... [ 60%] parallelisation
  | writing output... [ 80%] parameters
  | writing output... [100%] user_guide
  |  
  | generating indices... genindex done
  | writing additional pages... search done
  | copying images... [ 33%] images/digits.png
  | copying images... [ 67%] images/strings.png
  | copying images... [100%] images/graph_sp.png
  |  
  | dumping search index in English (code: en)... done
  | dumping object inventory... done
  | build finished with problems, 4 warnings.


```

</details>

This PR ensures that the correct locations are added to `sys.path`, so that building the docs always works from anywhere.