### PR TITLE
Make imports consistent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,10 @@ repos:
     hooks:
       - id: black
         language_version: python3.13
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0
     hooks:

--- a/annchor/__init__.py
+++ b/annchor/__init__.py
@@ -1,2 +1,4 @@
 # (C) Crown Copyright GCHQ
-from .annchor import *
+from annchor.annchor import Annchor, BruteForce, compare_neighbor_graphs
+
+__all__ = ("Annchor", "BruteForce", "compare_neighbor_graphs")

--- a/annchor/annchor.py
+++ b/annchor/annchor.py
@@ -1,35 +1,33 @@
 # (C) Crown Copyright GCHQ
-import numpy as np
 import time
-
-from numba import prange, types
-from numba.typed import Dict
-
 from collections import Counter
 
-from annchor.utils import (
-    get_function_from_input,
-    get_exact_ijs_,
-    test_parallelisation,
-    get_check,
-    get_dad_ijs,
-    get_IJs_from_check,
-    check_locality_size,
-    get_bounds_njit_ijs,
-    update_bounds,
-    np_sum,
-    guarantee_nmin,
-    get_probs,
-    get_nn,
-)
-from annchor.pickers import MaxMinAnchorPicker
-from annchor.samplers import SimpleStratifiedSampler, NothingToSample
-from annchor.regressors import SimpleStratifiedLinearRegression
-from annchor.error_predictors import SimpleStratifiedErrorRegression
-from annchor.query_functions import query_
-
+import numpy as np
+from numba import prange, types
+from numba.typed import Dict
 from scipy.sparse import dok_matrix
 from tqdm.auto import tqdm as tq
+
+from annchor.error_predictors import SimpleStratifiedErrorRegression
+from annchor.pickers import MaxMinAnchorPicker
+from annchor.query_functions import query_
+from annchor.regressors import SimpleStratifiedLinearRegression
+from annchor.samplers import NothingToSample, SimpleStratifiedSampler
+from annchor.utils import (
+    check_locality_size,
+    get_bounds_njit_ijs,
+    get_check,
+    get_dad_ijs,
+    get_exact_ijs_,
+    get_function_from_input,
+    get_IJs_from_check,
+    get_nn,
+    get_probs,
+    guarantee_nmin,
+    np_sum,
+    test_parallelisation,
+    update_bounds,
+)
 
 
 class Annchor:

--- a/annchor/annchor.py
+++ b/annchor/annchor.py
@@ -4,18 +4,32 @@ import time
 
 from numba import prange, types
 from numba.typed import Dict
-from numba.core.registry import CPUDispatcher
 
 from collections import Counter
 
-from annchor.utils import *
-from annchor.pickers import *
-from annchor.samplers import *
-from annchor.regressors import *
-from annchor.error_predictors import *
-from annchor.query_functions import *
+from annchor.utils import (
+    get_function_from_input,
+    get_exact_ijs_,
+    test_parallelisation,
+    get_check,
+    get_dad_ijs,
+    get_IJs_from_check,
+    check_locality_size,
+    get_bounds_njit_ijs,
+    update_bounds,
+    np_sum,
+    guarantee_nmin,
+    get_probs,
+    get_nn,
+)
+from annchor.pickers import MaxMinAnchorPicker
+from annchor.samplers import SimpleStratifiedSampler, NothingToSample
+from annchor.regressors import SimpleStratifiedLinearRegression
+from annchor.error_predictors import SimpleStratifiedErrorRegression
+from annchor.query_functions import query_
 
 from scipy.sparse import dok_matrix
+from tqdm.auto import tqdm as tq
 
 
 class Annchor:

--- a/annchor/annchor.py
+++ b/annchor/annchor.py
@@ -1,10 +1,9 @@
 # (C) Crown Copyright GCHQ
-import os
 import numpy as np
 import time
 
-from numba import njit, prange, types, typeof
-from numba.typed import Dict, List
+from numba import prange, types
+from numba.typed import Dict
 from numba.core.registry import CPUDispatcher
 
 from collections import Counter

--- a/annchor/datasets.py
+++ b/annchor/datasets.py
@@ -1,5 +1,6 @@
 # (C) Crown Copyright GCHQ
 import os
+
 import numpy as np
 
 package_directory = os.path.dirname(os.path.abspath(__file__))

--- a/annchor/distances.py
+++ b/annchor/distances.py
@@ -1,8 +1,6 @@
 # (C) Crown Copyright GCHQ
-import os
 import numpy as np
 from numba import njit
-import scipy
 import Levenshtein as lev
 
 

--- a/annchor/distances.py
+++ b/annchor/distances.py
@@ -1,7 +1,7 @@
 # (C) Crown Copyright GCHQ
+import Levenshtein as lev
 import numpy as np
 from numba import njit
-import Levenshtein as lev
 
 
 @njit

--- a/annchor/error_predictors.py
+++ b/annchor/error_predictors.py
@@ -3,7 +3,6 @@ import numpy as np
 
 
 import os
-from annchor.utils import *
 
 
 CPU_COUNT = os.cpu_count()

--- a/annchor/error_predictors.py
+++ b/annchor/error_predictors.py
@@ -1,9 +1,7 @@
 # (C) Crown Copyright GCHQ
-import numpy as np
-
-
 import os
 
+import numpy as np
 
 CPU_COUNT = os.cpu_count()
 

--- a/annchor/error_predictors.py
+++ b/annchor/error_predictors.py
@@ -1,17 +1,10 @@
 # (C) Crown Copyright GCHQ
-from abc import ABC, abstractmethod
-
 import numpy as np
 
 
-from joblib import Parallel, delayed
-from sklearn.linear_model import LinearRegression
 import os
 from annchor.utils import *
-from numba import njit, prange, types
-from numba.typed import Dict
 
-from tqdm.auto import tqdm as tq
 
 CPU_COUNT = os.cpu_count()
 

--- a/annchor/pickers.py
+++ b/annchor/pickers.py
@@ -1,15 +1,8 @@
 # (C) Crown Copyright GCHQ
-from abc import ABC, abstractmethod
-
 import numpy as np
 
-
-from joblib import Parallel, delayed
-from sklearn.linear_model import LinearRegression
 import os
 from annchor.utils import *
-from numba import njit, prange, types
-from numba.typed import Dict
 
 from tqdm.auto import tqdm as tq
 

--- a/annchor/pickers.py
+++ b/annchor/pickers.py
@@ -1,10 +1,14 @@
 # (C) Crown Copyright GCHQ
 import numpy as np
+from typing import TYPE_CHECKING
 
 import os
-from annchor.utils import *
+from annchor.utils import np_min
 
 from tqdm.auto import tqdm as tq
+
+if TYPE_CHECKING:
+    from annchor import Annchor
 
 CPU_COUNT = os.cpu_count()
 

--- a/annchor/pickers.py
+++ b/annchor/pickers.py
@@ -1,11 +1,11 @@
 # (C) Crown Copyright GCHQ
-import numpy as np
+import os
 from typing import TYPE_CHECKING
 
-import os
-from annchor.utils import np_min
-
+import numpy as np
 from tqdm.auto import tqdm as tq
+
+from annchor.utils import np_min
 
 if TYPE_CHECKING:
     from annchor import Annchor

--- a/annchor/query_functions.py
+++ b/annchor/query_functions.py
@@ -1,15 +1,14 @@
 # (C) Crown Copyright GCHQ
 import numpy as np
-
 from numba import njit, prange, types
 from numba.typed import Dict
 
 from annchor.utils import (
-    np_argmin,
-    guarantee_nmin,
-    get_probs,
     get_exact_query_ijs_,
     get_nn,
+    get_probs,
+    guarantee_nmin,
+    np_argmin,
 )
 
 

--- a/annchor/query_functions.py
+++ b/annchor/query_functions.py
@@ -3,7 +3,6 @@ import numpy as np
 
 from numba import njit, prange, types
 from numba.typed import Dict
-from numba.core.registry import CPUDispatcher
 
 from annchor.utils import *
 

--- a/annchor/query_functions.py
+++ b/annchor/query_functions.py
@@ -4,7 +4,13 @@ import numpy as np
 from numba import njit, prange, types
 from numba.typed import Dict
 
-from annchor.utils import *
+from annchor.utils import (
+    np_argmin,
+    guarantee_nmin,
+    get_probs,
+    get_exact_query_ijs_,
+    get_nn,
+)
 
 
 def get_query_anchor_dists(ann, Q):

--- a/annchor/regressors.py
+++ b/annchor/regressors.py
@@ -1,6 +1,4 @@
 # (C) Crown Copyright GCHQ
-from abc import ABC, abstractmethod
-
 import numpy as np
 
 
@@ -8,10 +6,6 @@ from joblib import Parallel, delayed
 from sklearn.linear_model import LinearRegression
 import os
 from annchor.utils import *
-from numba import njit, prange, types
-from numba.typed import Dict
-
-from tqdm.auto import tqdm as tq
 
 CPU_COUNT = os.cpu_count()
 

--- a/annchor/regressors.py
+++ b/annchor/regressors.py
@@ -1,10 +1,9 @@
 # (C) Crown Copyright GCHQ
+import os
+
 import numpy as np
-
-
 from joblib import Parallel, delayed
 from sklearn.linear_model import LinearRegression
-import os
 
 CPU_COUNT = os.cpu_count()
 

--- a/annchor/regressors.py
+++ b/annchor/regressors.py
@@ -5,7 +5,6 @@ import numpy as np
 from joblib import Parallel, delayed
 from sklearn.linear_model import LinearRegression
 import os
-from annchor.utils import *
 
 CPU_COUNT = os.cpu_count()
 

--- a/annchor/samplers.py
+++ b/annchor/samplers.py
@@ -1,13 +1,12 @@
 # (C) Crown Copyright GCHQ
+import os
 from abc import ABC, abstractmethod
 
 import numpy as np
-
-
-import os
-from annchor.utils import loop_partitions
 from numba import types
 from numba.typed import Dict
+
+from annchor.utils import loop_partitions
 
 CPU_COUNT = os.cpu_count()
 

--- a/annchor/samplers.py
+++ b/annchor/samplers.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 import os
-from annchor.utils import *
+from annchor.utils import loop_partitions
 from numba import types
 from numba.typed import Dict
 

--- a/annchor/samplers.py
+++ b/annchor/samplers.py
@@ -4,14 +4,10 @@ from abc import ABC, abstractmethod
 import numpy as np
 
 
-from joblib import Parallel, delayed
-from sklearn.linear_model import LinearRegression
 import os
 from annchor.utils import *
-from numba import njit, prange, types
+from numba import types
 from numba.typed import Dict
-
-from tqdm.auto import tqdm as tq
 
 CPU_COUNT = os.cpu_count()
 

--- a/annchor/tests/test_annchor.py
+++ b/annchor/tests/test_annchor.py
@@ -1,12 +1,11 @@
 # (C) Crown Copyright GCHQ
+import networkx as nkx
 import numpy as np
 from numba import njit
 from pynndescent.distances import kantorovich
-import networkx as nkx
 
 from annchor import Annchor, BruteForce, compare_neighbor_graphs
-from annchor import Annchor, compare_neighbor_graphs
-from annchor.datasets import load_digits, load_strings, load_graph_sp
+from annchor.datasets import load_digits, load_graph_sp, load_strings
 
 # Set interation count for tests with optional iterations
 niters = 1

--- a/annchor/tests/test_annchor.py
+++ b/annchor/tests/test_annchor.py
@@ -1,7 +1,6 @@
 # (C) Crown Copyright GCHQ
 import numpy as np
 from numba import njit
-import Levenshtein as lev
 from pynndescent.distances import kantorovich
 import networkx as nkx
 

--- a/annchor/tests/test_datasets.py
+++ b/annchor/tests/test_datasets.py
@@ -1,17 +1,11 @@
 # (C) Crown Copyright GCHQ
-import numpy as np
+import networkx as nx
 import numba
-
-from annchor.datasets import (
-    load_digits,
-    load_strings,
-    load_digits_large,
-    load_graph_sp,
-)
-from annchor.distances import levenshtein
+import numpy as np
 from pynndescent.distances import kantorovich
 
-import networkx as nx
+from annchor.datasets import load_digits, load_digits_large, load_graph_sp, load_strings
+from annchor.distances import levenshtein
 
 
 def test_digits():

--- a/annchor/tests/test_datasets.py
+++ b/annchor/tests/test_datasets.py
@@ -1,5 +1,4 @@
 # (C) Crown Copyright GCHQ
-import sys
 import numpy as np
 import numba
 

--- a/annchor/tests/test_distances.py
+++ b/annchor/tests/test_distances.py
@@ -1,5 +1,6 @@
 # (C) Crown Copyright GCHQ
 import numpy as np
+
 from annchor.distances import euclidean, levenshtein
 
 

--- a/annchor/tests/test_distances.py
+++ b/annchor/tests/test_distances.py
@@ -1,6 +1,5 @@
 # (C) Crown Copyright GCHQ
 import numpy as np
-from annchor.datasets import load_digits
 from annchor.distances import euclidean, levenshtein
 
 

--- a/annchor/tests/test_examples.py
+++ b/annchor/tests/test_examples.py
@@ -1,9 +1,9 @@
 # (C) Crown Copyright GCHQ
 from collections import Counter
 
-from numba import njit
 import numpy as np
-from sklearn.datasets import make_moons, make_blobs
+from numba import njit
+from sklearn.datasets import make_blobs, make_moons
 from sklearn.model_selection import train_test_split
 
 from annchor import Annchor, BruteForce, compare_neighbor_graphs

--- a/annchor/utils.py
+++ b/annchor/utils.py
@@ -1,20 +1,17 @@
 # (C) Crown Copyright GCHQ
-import numpy as np
-
-from numba import njit, prange, types, typeof
-from numba.typed import Dict, List
-from numba.core.registry import CPUDispatcher
-
-from joblib import Parallel, delayed
-
 import os
+from multiprocessing.context import TimeoutError
+
+import numpy as np
+from joblib import Parallel, delayed
+from numba import njit, prange, typeof, types
+from numba.core.registry import CPUDispatcher
+from numba.typed import Dict, List
+from pynndescent.distances import kantorovich
+from scipy.spatial.distance import cosine
 from tqdm.auto import tqdm as tq
 
 from annchor.distances import euclidean, levenshtein
-from pynndescent.distances import kantorovich
-from scipy.spatial.distance import cosine
-
-from multiprocessing.context import TimeoutError
 
 CPU_COUNT = os.cpu_count()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,7 @@ sort = "Cover"
 exclude_also = [
     "@abstractmethod$"
 ]
+
+
+[tool.isort]
+profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # (C) Crown Copyright GCHQ
 from setuptools import setup
 
-
 if __name__ == "__main__":
     setup()


### PR DESCRIPTION
This PR makes a few changes to the code imports:

* All imports are absolute instead of relative.
* All unused imports have been removed.
* All `from x import *` imports have been replaced with the specific things that are being imported.
* Added `isort` pre-commit hook to consistently sort imports. This has been done to ensure it plays well with `black`.

One notable change is that `annchor/__init__.py` used to import everything from the library (`from .annchor import *`). I've replaced this with three specific imports (`Annchor`, `BruteForce` and `compare_neighbor_graphs`) which were needed to run the tests, but which appear to be the only things imported in the README and the example notebooks.

**Please note** however that technically this means changing the public API of the package. The repo displayed a "beta" flag before but the version was technically `>=1`, so  arguably this a backwards-incompatible change. I'll leave it up to you how you want to approach this, given the expected usage of the package?