### PR TITLE
Format docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,10 @@ repos:
     rev: "0.33.2"
     hooks:
       - id: check-github-workflows
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.9.0
+    hooks:
+      - id: numpydoc-validation
   - repo: https://github.com/regebro/pyroma
     rev: "5.0"
     hooks:

--- a/annchor/annchor.py
+++ b/annchor/annchor.py
@@ -31,15 +31,16 @@ from annchor.utils import (
 
 
 class Annchor:
-    """Annchor
+    """
+    Annchor.
 
-    Quickly computes the approximate k-NN graph for slow metrics
+    Quickly computes the approximate k-NN graph for slow metrics.
 
     Parameters
     ----------
-    X: np.array or list (required)
+    X : np.array or list (required)
         The data set for which we want to find the k-NN graph.
-    func: function, numba-jitted function or string (required)
+    func : function, numba-jitted function or str (required)
         The metric under which the k-NN graph should be evaluated.
         This can be a user supplied function or a string.
         Currently supported string arguments are:
@@ -48,57 +49,58 @@ class Annchor:
             * cosine
             * levenshtein
             * wasserstein  (requires cost_matrix kwarg)
-    func_kwargs: dict (optional, default None)
-        Dictionary of keyword arguments for the metric
-    n_anchors: int (optional, default 20)
+    func_kwargs : dict (optional, default None)
+        Dictionary of keyword arguments for the metric.
+    n_anchors : int (optional, default 20)
         The number of anchor points. Increasing the number of anchors
         increases the k-NN graph accuracy at the expense of speed.
-    n_neighbors: int (optional, default 15)
+    n_neighbors : int (optional, default 15)
         The number of nearest neighbors to compute (i.e. the value of k
         for the k-NN graph).
-    n_samples: int (optional, default 5000)
+    n_samples : int (optional, default 5000)
         The number of sample distances used to compute the error distribution
         (E = d-dhat).
-    p_work: float (optional, default 0.1)
+    p_work : float (optional, default 0.1)
         The approximate percentage of brute force calculations which
         we are willing to make.
-    anchor_picker: AnchorPicker (optional, default MaxMinAnchorPicker())
+    anchor_picker : AnchorPicker (optional, default MaxMinAnchorPicker())
         The anchor picker class which specifies the anchor points.
-    sampler: Sampler (optional, default SimpleStratifiedSampler())
+    sampler : Sampler (optional, default SimpleStratifiedSampler())
         The sampler class which chooses the sample pairs.
-    regression: Regression
+    regression : Regression
         (optional, default SimpleStratifiedLinearRegression())
         The regression class which predicts distances from features.
-    error_predictor: ErrorRegression
+    error_predictor : ErrorRegression
         (optional, default SimpleStratifiedErrorRegression())
         The error regression class which predicts error distributions.
-    locality: int (optional, default 5)
+    random_seed : int
+    locality : int (optional, default 5)
         The number of anchor points to use in the permutation based k-NN
         (dhat) step.
-    loc_thresh: int (optional, default 1)
+    loc_thresh : int (optional, default 1)
         The minimum number of anchors in common for which we allow an item
         into NN_x.
-    loc_min: int (optional, default 10*n_neighbors)
-        The minimum number of points in NN_x
-    verbose: bool (optional, default False)
+    loc_min : int (optional, default 10*n_neighbors)
+        The minimum number of points in NN_x.
+    verbose : bool (optional, default False)
         Set verbose=True for more interim output.
-    is_metric: bool (optional, default True)
+    is_metric : bool (optional, default True)
         Set is_metric=False if the metric may violate the triangle inequality.
         With is_metric=True, predictions are clipped between upper/lower
         bounds, which may not be accurate if triangle inequality is violated.
-    get_exact_ijs: function (optional, default None)
+    get_exact_ijs : function (optional, default None)
         An optional user supplied function for evaluating the metric on an
         array of indices. Useful if you wish to supply your own
         parallelisation.
         get_exact_ijs(f,X,IJ) should return
         np.array([f(X[i],X[j] for i,j in IJ]).
-    backend: string (optional, default "loky")
+    backend : str (optional, default "loky")
         Specifies the joblib Parallel backend.
         Can be "loky" or "multiprocessing"
         In general "loky" seems to be more robust, but occasionally
-        "multiprocessing" can be significantly faster
-
-
+        "multiprocessing" can be significantly faster.
+    niters : int
+    lookahead : int
     """
 
     def __init__(
@@ -200,14 +202,14 @@ class Annchor:
 
     def get_anchors(self):
         """
-        Gets the anchors and distances to anchors.
+        Get the anchors and distances to anchors.
+
         Anchors are stored in self.A, distances in self.D.
 
         self.A: np.array, shape=(n_anchors,)
             Array of anchor indices.
         self.D: np.array, shape=(nx, n_anchors)
             Array of distances to anchor points.
-
         """
 
         self.A, self.D, evals = self.anchor_picker.get_anchors(self)
@@ -216,7 +218,7 @@ class Annchor:
 
     def get_locality(self):
         """
-        Uses basic permutation/set method to find candidate nearest neighbours.
+        Use basic permutation/set method to find candidate nearest neighbours.
 
         Current Technique (Use something better in future):
             For each point i, find the set S_i of its nearest l=locality anchor
@@ -227,7 +229,6 @@ class Annchor:
         self.check: Dict, keys=int64, val=int64[:]
             check[i] is the array of candidate nearest neighbour indices for
             index j.
-
         """
         na = self.n_anchors
         nx = self.nx
@@ -262,22 +263,22 @@ class Annchor:
 
     def get_features_IJ(self, IJs, I):
         """
-        Computes features for distances in IJs.
+        Compute features for distances in IJs.
 
         Parameters
         ----------
-        IJs: np.array, shape=(?,2)
+        IJs : np.array, shape=(?,2)
             Indices of distances for which we will find features.
-        I: numba.typed.Dict dict of arrays
+        I : numba.typed.Dict dict of arrays
             I[i] is the array of indices into IJs which contain index i.
 
-        Outputs
+        Returns
         -------
-        feature_names: List
-            List of features names (as strings)
-        features: np.array
-            Array of features corresponding to distances in ijs
-        not_computed_mask: np.array
+        feature_names : List
+            List of features names (as strings).
+        features : np.array
+            Array of features corresponding to distances in ijs.
+        not_computed_mask : np.array
             Array of bools indicating whether or not a distance in IJs
             has been explicitly computed.
         """
@@ -316,7 +317,7 @@ class Annchor:
 
     def get_sample(self):
         """
-        Gets the sample of pairwise distances on which to train dhat/errors.
+        Get the sample of pairwise distances on which to train dhat/errors.
 
         self.G: np.array, shape=(n_samples,3)
             Array storing the sample distances and features (for future
@@ -523,7 +524,7 @@ class Annchor:
 
     def fit(self):
         """
-        Computes the approx nearest neighbour graph.
+        Compute the approx nearest neighbour graph.
         """
 
         def timeit(item, origin, start):
@@ -615,7 +616,7 @@ class Annchor:
 
     def to_sparse_matrix(self):
         """
-        Returns the K-NN graph as a dictionary of keys sparse distance matrix.
+        Return the K-NN graph as a dictionary of keys sparse distance matrix.
         """
 
         # Initialise sparse matrix
@@ -637,15 +638,15 @@ class Annchor:
 
         Parameters
         ----------
-        Q: np.array, shape=(n_samples, n_features)
-            The new data to query against X
-        nn: int > 0
-            Desired number of nearest neighbours
-        p_work: 0.0 < float < 1.0
+        Q : np.array, shape=(n_samples, n_features)
+            The new data to query against X.
+        nn : int > 0
+            Desired number of nearest neighbours.
+        p_work : 0.0 < float < 1.0
             Fraction of brute force work to perform. A value of p_work=1 will
             carry out len(Q)*len(X) distance computations (equivalent to brute
             forcing the solution).
-        get_exact_query_ijs: function (optional, default None)
+        get_exact_query_ijs : function (optional, default None)
             An optional user supplied function for evaluating the metric on an
             array of indices. Useful if you wish to supply your own
             parallelisation. get_exact_ijs(f,X,Z,IJ) is the function should
@@ -675,20 +676,20 @@ class Annchor:
 
     def get_nearest_enemies(self, y, nn=3, loc_min=100):
         """
-        Computes the nearest enemy graph
-        Result is stored in self.nearest_enemy_graph
+        Compute the nearest enemy graph.
+
+        The result is stored in self.nearest_enemy_graph.
 
         Parameters
         ----------
-        y: np.array, shape=(len(X),)
-            Data labels (corresponding to elements in X)
-        nn: int > 0
-            Desired number of nearest enemies
-        loc_min: int > 0
+        y : np.array, shape=(len(X),)
+            Data labels (corresponding to elements in X).
+        nn : int > 0
+            Desired number of nearest enemies.
+        loc_min : int > 0
             Minimum number of points to store in locality (i.e. for each
             index we will compute features for at least loc_min points, if
-            possible.)
-
+            possible).
         """
         nx = self.nx
         lens = "len(y)=%d, len(X)=%d" % (len(y), nx)
@@ -773,25 +774,25 @@ class Annchor:
 
     def annchor_selective_subset(self, y, dne=None, alpha=0):
         """
-        Generates a selective subset for X given labels y.
+        Generate a selective subset for X given labels y.
 
         Parameters
         ----------
-        y: np.array, shape=(len(X),)
-            Data labels (corresponding to elements in X)
-        dne: tuple or None (optional, default=None)
+        y : np.array, shape=(len(X),)
+            Data labels (corresponding to elements in X).
+        dne : tuple or None (optional, default=None)
             The nearest enemy graph for X,y.
             dne[0] are the indices of the nearest enemies for points in X.
             dne[1] are the corresponding distances.
-        alpha: float (default=0)
+        alpha : float (default=0)
             Value for alpha-ss. The nearest enemy distance is multiplied by
             1/(1+alpha), to account for approximate nearest neighbour methods.
             In practice, larger alpha values make the subset more robust to
             errors at the expense of increasing the size of the subset.
 
-        Outputs
+        Returns
         -------
-        ss: np.array
+        np.array
             The indices of X which form the selective subset.
         """
 
@@ -911,15 +912,16 @@ class Annchor:
 
 
 class BruteForce:
-    """BruteForce
+    """
+    BruteForce.
 
-    Computes the approximate k-NN graph by brute force
+    Computes the approximate k-NN graph by brute force.
 
     Parameters
     ----------
-    X: np.array or list (required)
+    X : np.array or list
         The data set for which we want to find the k-NN graph.
-    func: function, numba-jitted function (required) or string.
+    func : function, numba-jitted function or str
         The metric under which the k-NN graph should be evaluated.
         This can be a user supplied function or a string.
         Currently supported string arguments are:
@@ -927,19 +929,20 @@ class BruteForce:
             * euclidean
             * cosine
             * levenshtein
-    func_kwargs: dict (optional, default None)
-        Dictionary of keyword arguments for the metric
-    get_exact_ijs: function (optional, default None)
+    func_kwargs : dict (optional, default None)
+        Dictionary of keyword arguments for the metric.
+    verbose : bool
+    get_exact_ijs : function (optional, default None)
         An optional user supplied function for evaluating the metric on an
         array of indices. Useful if you wish to supply your own
         parallelisation.
         get_exact_ijs(f,X,IJ) should return
         np.array([f(X[i],X[j] for i,j in IJ]).
-    backend: string (optional, default "loky")
+    backend : str (optional, default "loky")
         Specifies the joblib Parallel backend.
         Can be "loky" or "multiprocessing"
         In general "loky" seems to be more robust, but occasionally
-        "multiprocessing" can be significantly faster
+        "multiprocessing" can be significantly faster.
     """
 
     def __init__(
@@ -970,11 +973,7 @@ class BruteForce:
         test_parallelisation(self.get_exact_ijs, self.f, self.X, self.nx, backend, s=20)
 
     def fit(self):
-        """get_neighbor_graph
-
-        Gets the k-NN graph from the all pairs distance matrix
-
-        """
+        """Get the k-NN graph from the all pairs distance matrix."""
 
         IJs = np.array(
             [(i, j) for i in range(self.nx - 1) for j in range(i + 1, self.nx)]
@@ -992,10 +991,10 @@ class BruteForce:
 
 
 def compare_neighbor_graphs(nng_1, nng_2, n_neighbors):
-    """compare_neighbor_graphs
+    """
+    Compare the accuracy of two k-NN graphs.
 
-    Compares accuracy of k-NN graphs. The second graph is compared against the
-    first.
+    The second graph is compared against the first.
     This measure of accuracy accounts for cases where the indices differ but
     the distances are equivalent.
 
@@ -1008,18 +1007,17 @@ def compare_neighbor_graphs(nng_1, nng_2, n_neighbors):
 
     Parameters
     ----------
-    nng_1: nearest neighbour graph (tuple of np.array)
+    nng_1 : nearest neighbour graph (tuple of np.array)
         The first nearest neighbour graph, (indices, distances).
-    nng_2: nearest neighbour graph (tuple of np.array)
-        The second nearest neighbour graph, (indices, distances)..
-    n_neighbors: int
-        The number of nearest neighbors to consider
+    nng_2 : nearest neighbour graph (tuple of np.array)
+        The second nearest neighbour graph, (indices, distances).
+    n_neighbors : int
+        The number of nearest neighbors to consider.
 
     Returns
     -------
     err: int
         The number of incorrect NN pairs.
-
     """
 
     nx = nng_1[0].shape[0]

--- a/annchor/annchor.py
+++ b/annchor/annchor.py
@@ -45,10 +45,10 @@ class Annchor:
         This can be a user supplied function or a string.
         Currently supported string arguments are:
 
-            * euclidean
-            * cosine
-            * levenshtein
-            * wasserstein  (requires cost_matrix kwarg)
+        * euclidean
+        * cosine
+        * levenshtein
+        * wasserstein  (requires cost_matrix kwarg)
     func_kwargs : dict (optional, default None)
         Dictionary of keyword arguments for the metric.
     n_anchors : int (optional, default 20)
@@ -926,9 +926,9 @@ class BruteForce:
         This can be a user supplied function or a string.
         Currently supported string arguments are:
 
-            * euclidean
-            * cosine
-            * levenshtein
+        * euclidean
+        * cosine
+        * levenshtein
     func_kwargs : dict (optional, default None)
         Dictionary of keyword arguments for the metric.
     verbose : bool

--- a/annchor/datasets.py
+++ b/annchor/datasets.py
@@ -7,18 +7,14 @@ package_directory = os.path.dirname(os.path.abspath(__file__))
 
 
 def load_digits():
-    """load_digits
-
-    Loads the UCI OCR digits data test set (1797 8x8 images).
+    """
+    Load the UCI OCR digits data test set (1797 8x8 images).
 
     https://archive.ics.uci.edu/ml/datasets/optical+recognition+of+handwritten+digits
 
     Dua, D. and Graff, C. (2019). UCI Machine Learning Repository
     [http://archive.ics.uci.edu/ml]. Irvine, CA: University of California,
     School of Information and Computer Science.
-
-    Parameters
-    ----------
 
     Returns
     -------
@@ -48,18 +44,14 @@ def load_digits():
 
 
 def load_digits_large():
-    """load_digits_large
-
-    Loads the full (train+test) UCI OCR digits data set (5620 8x8 images).
+    """
+    Load the full (train+test) UCI OCR digits data set (5620 8x8 images).
 
     https://archive.ics.uci.edu/ml/datasets/optical+recognition+of+handwritten+digits
 
     Dua, D. and Graff, C. (2019). UCI Machine Learning Repository
     [http://archive.ics.uci.edu/ml]. Irvine, CA: University of California,
     School of Information and Computer Science.
-
-    Parameters
-    ----------
 
     Returns
     -------
@@ -89,13 +81,10 @@ def load_digits_large():
 
 
 def load_strings():
-    """load_strings
+    """
+    Load the string data set (1600 strings, length ~500).
 
-    Loads the string data set (1600 strings, length ~500). There are
-    8 clusters of two types: clouds (labels 0-4) and filaments (labels 5-7).
-
-    Parameters
-    ----------
+    There are 8 clusters of two types: clouds (labels 0-4) and filaments (labels 5-7).
 
     Returns
     -------
@@ -125,15 +114,11 @@ def load_strings():
 
 
 def load_graph_sp():
-    """load_graph_sp
+    """
+    Load the graph shortest path data set (800 vertices from a weighted graph).
 
-    Loads the graph shortest path data set (800 vertices from a weighted
-    graph).
     There are 10 clusters of vertices. The intra-cluster distances are shorter
     on average than the inter-cluster distances.
-
-    Parameters
-    ----------
 
     Returns
     -------

--- a/annchor/distances.py
+++ b/annchor/distances.py
@@ -8,6 +8,11 @@ from numba import njit
 def euclidean(x, y):
     """
     Euclidean distance.
+
+    Parameters
+    ----------
+    x : float
+    y : float
     """
     return np.linalg.norm(x - y)
 
@@ -15,5 +20,10 @@ def euclidean(x, y):
 def levenshtein(x, y):
     """
     Levenshtein distance.
+
+    Parameters
+    ----------
+    x : float
+    y : float
     """
     return lev.distance(x, y)

--- a/annchor/query_functions.py
+++ b/annchor/query_functions.py
@@ -73,21 +73,20 @@ def get_query_features(ann, QD, check):
 @njit(fastmath=True)
 def get_query_dad_ijs(IJs, D, QD):
     """
-    Calculates the double anchor distance for query pair (i,j).
-
+    Calculate the double anchor distance for query pair (i,j).
 
     Parameters
     ----------
-    IJs: np.array, shape=(?,2)
-        Array of i,j pairs
-    D: np.array, shape=(nx,na)
-        Array of distances to anchor points
-    QD: np.array, shape=(nx,na)
-        Array of query distances to anchor points
+    IJs : np.array, shape=(?,2)
+        Array of i,j pairs.
+    D : np.array, shape=(nx,na)
+        Array of distances to anchor points.
+    QD : np.array, shape=(nx,na)
+        Array of query distances to anchor points.
 
-    Outputs
+    Returns
     -------
-    dad: np.array, shape=(?,)
+    np.array, shape=(?,)
         Array of double anchor distances for pairs in IJs.
     """
     n = IJs.shape[0]
@@ -105,18 +104,18 @@ def get_query_dad_ijs(IJs, D, QD):
 @njit(parallel=True, fastmath=True)
 def get_query_bounds_njit_ijs(IJs, D, QD):
     """
-    Calculates the triangle inequality bounds for query pair (i,j).
+    Calculate the triangle inequality bounds for query pair (i,j).
 
     Parameters
     ----------
-    IJs: np.array, shape=(?,2)
-        Array of i,j pairs
-    D: np.array, shape=(nx,na)
-        Array of distances to anchor points
-    QD: np.array, shape=(nx,na)
-        Array of query distances to anchor points
+    IJs : np.array, shape=(?,2)
+        Array of i,j pairs.
+    D : np.array, shape=(nx,na)
+        Array of distances to anchor points.
+    QD : np.array, shape=(nx,na)
+        Array of query distances to anchor points.
 
-    Outputs
+    Returns
     -------
     bounds: np.array, shape=(?,2)
         Array of lower and upper bounds for pairs in IJs.

--- a/annchor/samplers.py
+++ b/annchor/samplers.py
@@ -18,6 +18,7 @@ class NothingToSample(Exception):
 class Sampler(ABC):
     """
     Abstract base class for Samplers.
+
     They need to implement two methods, get_partition and sample_partition:
      * get_partition(sample_feature, n_samples) should return a
      pair (sample_bins, new_n_samples)
@@ -26,6 +27,11 @@ class Sampler(ABC):
     This base class implements sample_partition in a simple way, so descendants
     may either implement get_partition only, or optionally override
     sample_partition as well.
+
+    Parameters
+    ----------
+    partition_feature_name : str
+    n_partitions : int
     """
 
     def __init__(self, partition_feature_name, n_partitions):

--- a/annchor/tests/test_examples.py
+++ b/annchor/tests/test_examples.py
@@ -48,11 +48,11 @@ def test_query_example():
 
     assert 1 - (errs / total) >= 0.99
 
-    def get_most_common(arr):
+    def _get_most_common(arr):
         "Return the most common item from array arr"
         return Counter(arr).most_common(1)[0][0]
 
-    y_pred = np.array([get_most_common(y_train[Q[0][i]]) for i in range(len(X_test))])
+    y_pred = np.array([_get_most_common(y_train[Q[0][i]]) for i in range(len(X_test))])
 
     assert np.sum(y_pred == y_test) / len(y_test) >= 0.95
 

--- a/annchor/utils.py
+++ b/annchor/utils.py
@@ -21,8 +21,16 @@ int_list_dtype = typeof(List(np.arange(4)))
 @njit
 def np_apply_along_axis(func1d, axis, arr):
     """
+    Apply a function along a specific axis of an array.
+
     Numba support for numpy funcs with axis option.
     From github user joelrich: (https://github.com/numba/numba/issues/1269).
+
+    Parameters
+    ----------
+    func1d : function
+    axis : int
+    arr : numpy.array
     """
     assert arr.ndim == 2
     assert axis in [0, 1]
@@ -107,20 +115,24 @@ def get_function_from_input(func, func_kwargs):
 
 def get_exact_ijs_(f, parallel=True, verbose=False, backend="loky"):
     """
+    Return a partial distance function.
+
     Takes the metric f and returns the function get_exact_ijs(f,X,IJ), which
     calculates the distances between pairs given in array IJ.
 
     Parameters
     ----------
-    f: function
+    f : function
         The metric. Takes two points from the data set and calculates their
         distance.
+    parallel : bool
+    verbose : bool
+    backend : str
 
-
-    Outputs
+    Returns
     -------
-    get_exact_ijs: function
-        get_exact_ijs(f,X,IJ) is the function that returns distances between
+    function
+        The partial get_exact_ijs(f,X,IJ) is the function that returns distances between
         pairs given in array IJ,
         i.e. np.array([f(X[i],X[j]) for i,j in IJ]).
     """
@@ -177,19 +189,25 @@ def get_exact_ijs_(f, parallel=True, verbose=False, backend="loky"):
 
 def get_exact_query_ijs_(f, parallel=True, verbose=False, backend="loky"):
     """
-    Takes the metric f and returns the function
-    get_exact_query_ijs(f,X, Z, IJ), which calculates the distances between
+    Take the metric f and return a query function.
+
+    Return get_exact_query_ijs(f,X, Z, IJ), which calculates the distances between
     pairs X[i], Z[j] given in array IJ.
+
     Parameters
     ----------
-    f: function
+    f : function
         The metric. Takes two points from the data set and calculates their
         distance.
-    Outputs
+    parallel : bool
+    verbose : bool
+    backend : str
+
+    Returns
     -------
-    get_exact_ijs: function
-        get_exact_ijs(f,X,Z,IJ) is the function that returns distances between
-        pairs given in array IJ,
+    function
+        The partial get_exact_ijs(f,X,Z,IJ) is the function that returns distances
+        between pairs given in array IJ,
         i.e. np.array([f(X[i],Z[j]) for i,j in IJ]).
     """
     if not parallel:
@@ -272,19 +290,18 @@ def test_parallelisation(get_exact_ijs, f, X, nx, backend, s=20):
 @njit(parallel=True, fastmath=True)
 def get_bounds_njit_ijs(IJs, D):
     """
-    Calculates the triangle inequality bounds for pair (i,j).
+    Calculate the triangle inequality bounds for pair (i,j).
 
     Parameters
     ----------
-    IJs: np.array, shape=(?,2)
-        Array of i,j pairs
-    D: np.array, shape=(nx,na)
-        Array of distances to anchor points
+    IJs : np.array, shape=(?,2)
+        Array of i,j pairs.
+    D : np.array, shape=(nx,na)
+        Array of distances to anchor points.
 
-
-    Outputs
+    Returns
     -------
-    bounds: np.array, shape=(?,2)
+    np.array, shape=(?,2)
         Array of lower and upper bounds for pairs in IJs.
     """
 
@@ -303,6 +320,13 @@ def get_bounds_njit_ijs(IJs, D):
 def get_bounds_alt(disi, disj, dsi, dsj):
     """
     Convoluted function to get upper/lower bounds quickly.
+
+    Parameters
+    ----------
+    disi : np.array
+    disj : np.array
+    dsi : np.array
+    dsj : np.array
     """
     ub, lb = np.inf, 0
     j0 = 0
@@ -324,20 +348,20 @@ def get_bounds_alt(disi, disj, dsi, dsj):
 @njit(parallel=True)
 def update_bounds(IJs, dis, ds):
     """
-    Updates the bounds on distances i,j in IJ.
+    Update the bounds on distances i,j in IJ.
 
     Parameters
     ----------
-    IJs: np.array, shape=(?,2)
-        Array of i,j pairs
-    dis: numba.typed.Dict
-        Dict of computed pair indices (sorted by dist)
-    ds: numba.typed.Dict
-        Dict of computed pair distances (sorted by dist)
+    IJs : np.array, shape=(?,2)
+        Array of i,j pairs.
+    dis : numba.typed.Dict
+        Dict of computed pair indices (sorted by dist).
+    ds : numba.typed.Dict
+        Dict of computed pair distances (sorted by dist).
 
-    Outputs
+    Returns
     -------
-    bounds: np.array, shape=(?,2)
+    np.array, shape=(?,2)
         Array of upper/lower bounds for pairs in IJs.
     """
 
@@ -353,19 +377,18 @@ def update_bounds(IJs, dis, ds):
 @njit(fastmath=True)
 def get_dad_ijs(IJs, D):
     """
-    Calculates the double anchor distance for pair (i,j).
+    Calculate the double anchor distance for pair (i,j).
 
     Parameters
     ----------
-    IJs: np.array, shape=(?,2)
-        Array of i,j pairs
-    D: np.array, shape=(nx,na)
-        Array of distances to anchor points
+    IJs : np.array, shape=(?,2)
+        Array of i,j pairs.
+    D : np.array, shape=(nx,na)
+        Array of distances to anchor points.
 
-
-    Outputs
+    Returns
     -------
-    dad: np.array, shape=(?,)
+    np.array, shape=(?,)
         Array of double anchor distances for pairs in IJs.
     """
     n = IJs.shape[0]
@@ -381,32 +404,31 @@ def get_dad_ijs(IJs, D):
 @njit(parallel=True)
 def get_nn(nx, nn, RA, IJs, I, not_computed_mask):
     """
-    Calculates the nearest neighbor graph.
+    Calculate the nearest neighbor graph.
 
     Parameters
     ----------
-    nx: int
+    nx : int
         Number of points in the data set.
-    nn: int
+    nn : int
         Number of nearest neighbors.
-    RA: np.array
-        Array of refine approximate distances
-    IJs: np.array
-        Array of pairs i,j corresponding to the approx distances
-    I: dict
+    RA : np.array
+        Array of refine approximate distances.
+    IJs : np.array
+        Array of pairs i,j corresponding to the approx distances.
+    I : dict
         Dictionary mapping indices of the data set to indices in IJs/RA.
+    not_computed_mask : np.array
 
-
-    Outputs
+    Returns
     -------
     ngi: np.array, shape=(nx,nn)
-        neighbor graph indices.
+        Neighbor graph indices.
         ngi[i][j] is the index of the jth closest point to index i.
 
     ngd: np.array, shape=(nx,nn)
-        neighbor graph distances.
+        Neighbor graph distances.
         ngd[i][j] is the distance of the jth closest point to index i.
-
     """
     ngi = np.zeros(shape=(nx, nn - 1), dtype=np.int64)
     ngd = np.zeros(shape=(nx, nn - 1))

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,8 +29,8 @@ version = "v1.1.1"
 # -- General configuration ---------------------------------------------------
 
 extensions = [
-    "sphinx.ext.autodoc",
     "sphinx_rtd_theme",
+    "sphinx.ext.napoleon",
 ]
 
 html_theme = "sphinx_rtd_theme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,19 @@ exclude_also = [
 
 [tool.isort]
 profile = "black"
+
+
+
+[tool.numpydoc_validation]
+checks = [
+    "all",  # report on all checks, except the below
+    "EX01",  # No examples section found
+    "SA01",  # See Also section not found
+    "ES01",  # No extended summary found
+    "PR07",  # Parameter "x" has no description
+    "GL08",  # The object does not have a docstring
+    "RT01",  # No Returns section found
+]
+exclude = [  # don't report on objects that match any of these regex
+    "__init__",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,4 +90,5 @@ checks = [
 ]
 exclude = [  # don't report on objects that match any of these regex
     "__init__",
+    "\\._.*$",  # ignore all private objects, e.g. 'def _inner(self):'
 ]


### PR DESCRIPTION
This PR reformats the docstrings to ensure consistency, and to allow Sphinx to better showcase the function signatures.

* Added `numpydoc` pre-commit hook to force consistency across docstrings (and to ensure correct parsing).
* Amended certain docstrings to satisfy `numpydoc`.
* Added `sphinx.ext.napoleon` to properly parse parameters etc in the docs.

Certain `numpydoc` validations have been skipped for ease. Some we may wish to revert as we go, but this will be a future issue.

I suggest we squash these commits on merge.

### Before

<img width="766" height="677" alt="image" src="https://github.com/user-attachments/assets/d60dae2c-dae6-4329-b1da-1dbc62b1fc0f" />

### After

<img width="768" height="778" alt="image" src="https://github.com/user-attachments/assets/a4f4c4e8-845a-4050-95a2-f5c8f6def0df" />
